### PR TITLE
Feature/eodhp 994 status tracking

### DIFF
--- a/internal/k8s/workspace.go
+++ b/internal/k8s/workspace.go
@@ -18,8 +18,8 @@ func MapObjectStoresToS3Buckets(workspaceName string, c *utils.Config, objectSto
 	for _, obj := range objectStores {
 		buckets = append(buckets, workspacev1alpha1.S3Bucket{
 			Name:            obj.Name,
-			Path:            obj.Path,
-			EnvVar:          obj.EnvVar,
+			Path:            "/" + workspaceName,
+			EnvVar:          "S3_BUCKET_WORKSPACE",
 			AccessPointName: fmt.Sprintf("%s-%s-s3", c.AWS.Cluster, workspaceName),
 		})
 	}
@@ -96,6 +96,9 @@ func buildWorkspace(req models.WorkspaceSettings, c *utils.Config) *workspacev1a
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      req.Name,
 			Namespace: "workspaces",
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "workspace-operator",
+			},
 		},
 		Spec: workspacev1alpha1.WorkspaceSpec{
 			Namespace: "ws-" + req.Name,


### PR DESCRIPTION
- Added go routine to actually publish the `workspace` CR status updates to `workspace-status` topic.

This should have been part of eodhp-951-monitor-crd-status-changes (to include actually publishing it).

EODHP-994 status tracking story was blocked by this not being fully implemented.