### PR TITLE
Feature/eodhp 1103 follow api design

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: dockerbuild dockerpush test lint format setup clean
 
 # Variables
-VERSION ?= 0.1.1
+VERSION ?= 0.1.2
 IMAGENAME = eodhp-workspace-manager
 DOCKERREPO ?= public.ecr.aws/n1b3o1k2
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.23.5
 
 require (
-	github.com/EO-DataHub/eodhp-workspace-controller v0.0.0-20250129132555-9e8ac85ef5dd
+	github.com/EO-DataHub/eodhp-workspace-controller v0.0.0-20250127115446-123d59f16726
 	github.com/apache/pulsar-client-go v0.14.0
 	github.com/google/uuid v1.6.0
 	github.com/rs/zerolog v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.23.5
 
 require (
-	github.com/EO-DataHub/eodhp-workspace-controller v0.0.0-20250124142231-cf9563252e17
+	github.com/EO-DataHub/eodhp-workspace-controller v0.0.0-20250129132555-9e8ac85ef5dd
 	github.com/apache/pulsar-client-go v0.14.0
 	github.com/google/uuid v1.6.0
 	github.com/rs/zerolog v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.23.5
 
 require (
-	github.com/EO-DataHub/eodhp-workspace-controller v0.0.0-20250127115446-123d59f16726
+	github.com/EO-DataHub/eodhp-workspace-controller v0.0.0-20250129163210-6dc81f5c1b3c
 	github.com/apache/pulsar-client-go v0.14.0
 	github.com/google/uuid v1.6.0
 	github.com/rs/zerolog v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOEl
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/EO-DataHub/eodhp-workspace-controller v0.0.0-20250127115446-123d59f16726 h1:6yPziAaZ7CjWXCEPEXcQCPp8IsFZ/eW+IESApGr0Cqo=
-github.com/EO-DataHub/eodhp-workspace-controller v0.0.0-20250127115446-123d59f16726/go.mod h1:DbjUYBNjgyyDrvUqslkGJ7cLTOiT9DoFHLuZi022B+E=
+github.com/EO-DataHub/eodhp-workspace-controller v0.0.0-20250129163210-6dc81f5c1b3c h1:/4t4WgeOhsB4HFvlnZhubqNOd18Dkpw8PRJk1vS5mr0=
+github.com/EO-DataHub/eodhp-workspace-controller v0.0.0-20250129163210-6dc81f5c1b3c/go.mod h1:DbjUYBNjgyyDrvUqslkGJ7cLTOiT9DoFHLuZi022B+E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.11.5 h1:haEcLNpj9Ka1gd3B3tAEs9CpE0c+1IhoL59w/exYU38=

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOEl
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/EO-DataHub/eodhp-workspace-controller v0.0.0-20250129132555-9e8ac85ef5dd h1:vkI4OPBlGqaDfuxXruFrB9q4FjxndfVmU0kaRFO74LM=
-github.com/EO-DataHub/eodhp-workspace-controller v0.0.0-20250129132555-9e8ac85ef5dd/go.mod h1:DbjUYBNjgyyDrvUqslkGJ7cLTOiT9DoFHLuZi022B+E=
+github.com/EO-DataHub/eodhp-workspace-controller v0.0.0-20250127115446-123d59f16726 h1:6yPziAaZ7CjWXCEPEXcQCPp8IsFZ/eW+IESApGr0Cqo=
+github.com/EO-DataHub/eodhp-workspace-controller v0.0.0-20250127115446-123d59f16726/go.mod h1:DbjUYBNjgyyDrvUqslkGJ7cLTOiT9DoFHLuZi022B+E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.11.5 h1:haEcLNpj9Ka1gd3B3tAEs9CpE0c+1IhoL59w/exYU38=

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOEl
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/EO-DataHub/eodhp-workspace-controller v0.0.0-20250124142231-cf9563252e17 h1:qSCot7n7wvs57H66PxuzbiLb9cIWj9EdlpOQJicE81s=
-github.com/EO-DataHub/eodhp-workspace-controller v0.0.0-20250124142231-cf9563252e17/go.mod h1:DbjUYBNjgyyDrvUqslkGJ7cLTOiT9DoFHLuZi022B+E=
+github.com/EO-DataHub/eodhp-workspace-controller v0.0.0-20250129132555-9e8ac85ef5dd h1:vkI4OPBlGqaDfuxXruFrB9q4FjxndfVmU0kaRFO74LM=
+github.com/EO-DataHub/eodhp-workspace-controller v0.0.0-20250129132555-9e8ac85ef5dd/go.mod h1:DbjUYBNjgyyDrvUqslkGJ7cLTOiT9DoFHLuZi022B+E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.11.5 h1:haEcLNpj9Ka1gd3B3tAEs9CpE0c+1IhoL59w/exYU38=

--- a/models/workspace_settings.go
+++ b/models/workspace_settings.go
@@ -30,6 +30,7 @@ type ObjectStore struct {
 	Path           string    `json:"path"`
 	EnvVar         string    `json:"env_var"`
 	AccessPointArn string    `json:"access_point_arn"`
+	Host           string    `json:"host"`
 }
 
 // BlockStore represents a block storage entry with related metadata.

--- a/models/workspace_settings.go
+++ b/models/workspace_settings.go
@@ -27,10 +27,11 @@ type Stores struct {
 type ObjectStore struct {
 	StoreID        uuid.UUID `json:"store_id"`
 	Name           string    `json:"name"`
-	Path           string    `json:"path"`
+	Bucket         string    `json:"bucket"`
+	Prefix         string    `json:"prefix"`
+	Host           string    `json:"host"`
 	EnvVar         string    `json:"env_var"`
 	AccessPointArn string    `json:"access_point_arn"`
-	Host           string    `json:"host"`
 }
 
 // BlockStore represents a block storage entry with related metadata.

--- a/models/workspace_settings.go
+++ b/models/workspace_settings.go
@@ -37,5 +37,5 @@ type BlockStore struct {
 	StoreID       uuid.UUID `json:"store_id"`
 	Name          string    `json:"name"`
 	AccessPointID string    `json:"access_point_id"`
-	FSID          string    `json:"fs_id"`
+	MountPoint    string    `json:"mount_point"`
 }

--- a/models/workspace_settings.go
+++ b/models/workspace_settings.go
@@ -32,6 +32,7 @@ type ObjectStore struct {
 	Host           string    `json:"host"`
 	EnvVar         string    `json:"env_var"`
 	AccessPointArn string    `json:"access_point_arn"`
+	AccessURL      string    `json:"access_url"`
 }
 
 // BlockStore represents a block storage entry with related metadata.


### PR DESCRIPTION
- PV/PVC names based on the `<workspace-name>-<block-store-name>` template
- EFS Root directory now set to `/workspaces/<workspace-name>/<block-store-name>`
- Revised user response details - i.e. added `MountPoint`, removed `FSID` (not needed) etc..