### PR TITLE
replace membergroup with owner

### DIFF
--- a/internal/k8s/workspace.go
+++ b/internal/k8s/workspace.go
@@ -137,7 +137,7 @@ func CreateWorkspace(ctx context.Context, k8sClient client.Client, req models.Wo
 		return fmt.Errorf("failed to create workspace %s: %w", req.Name, err)
 	}
 
-	log.Info().Str("name", req.Name).Str("namespace", req.MemberGroup).Msg("Workspace successfully created")
+	log.Info().Str("name", req.Name).Str("namespace", req.Name).Msg("Workspace successfully created")
 	return nil
 }
 
@@ -163,7 +163,7 @@ func UpdateWorkspace(ctx context.Context, k8sClient client.Client, req models.Wo
 		return fmt.Errorf("failed to update workspace %s: %w", req.Name, err)
 	}
 
-	log.Info().Str("name", req.Name).Str("namespace", req.MemberGroup).Msg("Workspace successfully updated")
+	log.Info().Str("name", req.Name).Str("namespace", req.Name).Msg("Workspace successfully updated")
 	return nil
 }
 

--- a/internal/k8s/workspace_test.go
+++ b/internal/k8s/workspace_test.go
@@ -41,8 +41,8 @@ func TestCreateWorkspace(t *testing.T) {
 				Block:  []models.BlockStore{{Name: "data"}},
 			},
 		},
-		Status:      "creating",
-		MemberGroup: "team-a",
+		Status: "creating",
+		Owner:  "owner",
 	}
 
 	err := CreateWorkspace(ctx, fakeClient, payload, cfg)

--- a/models/workspace_settings.go
+++ b/models/workspace_settings.go
@@ -11,7 +11,7 @@ type WorkspaceSettings struct {
 	ID          uuid.UUID `json:"id"`
 	Name        string    `json:"name"`
 	Account     uuid.UUID `json:"account"`
-	MemberGroup string    `json:"member_group"`
+	Owner       string    `json:"owner"`
 	Status      string    `json:"status"`
 	Stores      *[]Stores `json:"stores"`
 	LastUpdated time.Time `json:"last_updated"`


### PR DESCRIPTION
Based on https://github.com/EO-DataHub/platform-bugs/issues/141

Requires adding an `Owner` field for the workspaces so that a member of a workspace can differentiate between member and owner roles.

Removed `MemberGroups` as this is same as the Workspace `Name` field.